### PR TITLE
add printContext method

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Places',
+      title: 'qwerty',
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
@@ -24,10 +24,13 @@ class MyFirstWidget extends StatelessWidget {
 
   int counter = 0;
 
+  //void printContext() => context.runtimeType;
+
   @override
   Widget build(BuildContext context) {
     counter++;
     print('MyFirstWidget build $counter');
+    //printContext();
     return Container(
       child: const Center(
         child: Text('Hello!'),
@@ -46,10 +49,13 @@ class MySecondWidget extends StatefulWidget {
 class _MySecondWidgetState extends State<MySecondWidget> {
   int counter = 0;
 
+  void printContext() => print(context.runtimeType);
+
   @override
   Widget build(BuildContext context) {
     counter++;
     print('MySecond Widget build: $counter');
+    printContext();
     return Container(
       child: const Center(
         child: Text('Hello!'),


### PR DESCRIPTION
1. Переименуйте файл main.dart в start.dart. Запустите проект. Почему результат именно таков?
_Переименование не повлияло на запуск проекта. Точкой входа осталась функция main(). В dart нет, на сколько я понимаю, жесткой связи, как в Java, между классом и названием файла._

2.Верните именование.

3.В файле main.dart создайте виджет приложения. Назовите его App.

4.В методе build() верните MaterialApp в поле home поставьте Stateless виджет из предыдущего домашнего задания(см. урок про виджеты). Рассмотрите его параметры. Задайте поле title. Запустите на Android. Где отобразится значение этого поля?
По описанию должно отображаться в названии открытых приложений. Но, честно говоря, у меня название не изменилось.

5.Перейдем к рассмотрению контекста. В вашем Stateless виджет создайте метод без аргументов, который будет возвращать context.runtimeType. Получится ли реализовать подобное в данном виджете?
Если  я правильно понял задание, то до вызова build() никакой контекст недоступен.

6.Проделайте предыдущий пункт в рамках Stateful. В чем разница?
у State нашелся контекст, хотя не уверен, что разобрался в этом вопросе. 